### PR TITLE
Remove max_size parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,10 +57,10 @@ Usage Example
 
     mask = adafruit_monsterm4sk.MonsterM4sk(i2c=i2c_bus)
 
-    left_group = displayio.Group(max_size=4)
+    left_group = displayio.Group()
     mask.left_display.show(left_group)
 
-    right_group = displayio.Group(max_size=4)
+    right_group = displayio.Group()
     mask.right_display.show(right_group)
 
     right_circle = Circle(SCREEN_SIZE // 2, SCREEN_SIZE // 2, 40, fill=0x0000FF)

--- a/examples/monsterm4sk_pumpkin_shifting_eyes.py
+++ b/examples/monsterm4sk_pumpkin_shifting_eyes.py
@@ -53,11 +53,11 @@ i2c_bus = board.I2C()
 mask = adafruit_monsterm4sk.MonsterM4sk(i2c=i2c_bus)
 
 # left eye group setup
-left_group = displayio.Group(max_size=4)
+left_group = displayio.Group()
 mask.left_display.show(left_group)
 
 # right eye group setup
-right_group = displayio.Group(max_size=4)
+right_group = displayio.Group()
 mask.right_display.show(right_group)
 
 # Add orange backgrounds to both groups

--- a/examples/monsterm4sk_rainbow_stars.py
+++ b/examples/monsterm4sk_rainbow_stars.py
@@ -24,10 +24,10 @@ i2c_bus = board.I2C()
 
 mask = adafruit_monsterm4sk.MonsterM4sk(i2c=i2c_bus)
 
-left_group = displayio.Group(max_size=4, scale=3)
+left_group = displayio.Group(scale=3)
 mask.left_display.show(left_group)
 
-right_group = displayio.Group(max_size=4, scale=3)
+right_group = displayio.Group(scale=3)
 mask.right_display.show(right_group)
 
 left_group.x = (SCREEN_SIZE - IMAGE_SIZE) // 2

--- a/examples/monsterm4sk_simpletest.py
+++ b/examples/monsterm4sk_simpletest.py
@@ -25,10 +25,10 @@ i2c_bus = board.I2C()
 
 mask = adafruit_monsterm4sk.MonsterM4sk(i2c=i2c_bus)
 
-left_group = displayio.Group(max_size=4)
+left_group = displayio.Group()
 mask.left_display.show(left_group)
 
-right_group = displayio.Group(max_size=4)
+right_group = displayio.Group()
 mask.right_display.show(right_group)
 
 right_circle = Circle(SCREEN_SIZE // 2, SCREEN_SIZE // 2, 40, fill=0x0000FF)


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

I don't have a MonsterM4sk to test with.