### PR TITLE
make right backlight use pwmio instead of pulseio

### DIFF
--- a/adafruit_monsterm4sk.py
+++ b/adafruit_monsterm4sk.py
@@ -30,7 +30,7 @@ Implementation Notes
 # imports
 import time
 import board
-import pulseio
+import pwmio
 import busio
 import digitalio
 from adafruit_seesaw.seesaw import Seesaw
@@ -110,7 +110,7 @@ class MonsterM4sk:
         self.left_display = ST7789(left_display_bus, width=240, height=240, rowstart=80)
 
         # right backlight on board
-        self.right_backlight = pulseio.PWMOut(
+        self.right_backlight = pwmio.PWMOut(
             board.RIGHT_TFT_LITE, frequency=5000, duty_cycle=0
         )
         # full brightness


### PR DESCRIPTION
This update will be needed for CircuitPython 7 where PWMOut has been removed from `pulseio`

Tested successfully with MonsterM4sk on 7.0.0 alpha5 by initializing the library and setting the right backlight to a non-default duty cycle.

Only the right backlight code changes because the other one is managed through the on-board seesaw.